### PR TITLE
Fixed the NaN Calculation

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -27,18 +27,15 @@ function saveParticipants() {
         }
 
         const spans = liElement.querySelectorAll("span");
-        const name = spans[NAME_POSITION].textContent;
-        const total = parseInt(
-            Array.from(spans)
-                .filter(
-                    (el) => el.getAttribute("class")?.indexOf("__price__") > -1
-                )[0]
-                ?.textContent.replace(/[^\d\.]/g, "")
-        ) || 0;
-
         const isHost =
             spans[NAME_POSITION].nextElementSibling?.textContent ==
             LANG.host[curLang];
+        const name = spans[NAME_POSITION].textContent;
+        const total = parseInt(
+            spans[isHost ? spans.length-1 : spans.length-2]?.textContent.replace(/[^\d\.]/g, "")
+        ) || 0;
+
+        
         participants[name] = {
             total,
             isHost,


### PR DESCRIPTION
### Background
About 2-3 weeks ago, the CibusSplitter chrome extension started to malfunction resulting in "NaN" calculations of the amount each participant of the order is owed.

## Remediation
After reviewing the code, it seems the issue was with the price extraction from the span, in which the code was looking for a `span` tag with a class attribute value of `__price__`
Wolt has published a new version that obscures the class names.

# Work Around
If the participant is the host, the last `span` tag is the price container, if he is not the host, the last one is the remove icon.
therefore, we have to take the one before it.

Should resolve #3 
